### PR TITLE
Initial aviary.yaml

### DIFF
--- a/aviary.yaml
+++ b/aviary.yaml
@@ -1,0 +1,1 @@
+version: 1


### PR DESCRIPTION
This repository does not yet have an `aviary.yaml` file. No special configuration is necessary, so no directives are being added.