### PR TITLE
Optimization + behavioral consistency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,4 +19,5 @@
   :codox {:output-path "documentation"
           :namespaces :all}
 
-  :profiles {:dev [{:dependencies [[criterium "0.4.3"]]}]})
+  :profiles {:dev [{:dependencies [[criterium "0.4.3"]]
+                    :jvm-opts ^:replace ["-XX:TieredStopAtLevel=4"]}]})

--- a/src/utiliva/core.clj
+++ b/src/utiliva/core.clj
@@ -343,9 +343,9 @@
      coll
      (let [len (count coll)
            arr (make-array Object len)
-           rmap (group-by (zip-from (range))
-                          (comp pred val)
-                          coll)
+           rmap (group-by-mutable (zip-from (range))
+                                  (comp pred val)
+                                  coll)
            fdefault (get fmap :default identity)
            results (pmap (fn [[r kvs]]
                            (when (not-empty kvs)
@@ -362,9 +362,9 @@
          ;; Can't assume any coll is finite
          len (count input)
          arr (make-array Object len)
-         rmap (group-by (zip-from (range))
-                         (comp pred first val)
-                         input)
+         rmap (group-by-mutable (zip-from (range))
+                                (comp pred first val)
+                                input)
          fdefault (get fmap :default (fn [id & _] id))
          results (pmap (fn [[r kvs]]
                          (when (not-empty kvs)

--- a/src/utiliva/core.clj
+++ b/src/utiliva/core.clj
@@ -14,7 +14,7 @@
 
 (ns utiliva.core
   (:import [clojure.lang MapEntry IDeref]
-           [java.util PriorityQueue])
+           [java.util PriorityQueue LinkedList])
   (:refer-clojure :exclude [keep group-by]))
 
 ;; https://gist.github.com/galdre/e1851f73f0de9d6ebbf847c91d908f5d
@@ -251,6 +251,39 @@
                                       x more))
             coll colls))))
 
+(defn ^:private group-by-mutable
+  "Behaves just like utiliva.core/group-by, but returns a map with linked-lists
+  rather than vectors as values."
+  ([f coll]
+   (persistent!
+    (reduce
+     (fn [ret x]
+       (let [k (f x)
+             pre-existing (get ret k)
+             ll (or pre-existing
+                    (LinkedList.))]
+         (.add ^LinkedList ll ^Object x)
+         (if-not pre-existing
+           (assoc! ret k ll)
+           ret)))
+     (transient {}) coll)))
+  ([xform f coll]
+   (persistent!
+    (transduce xform
+               (fn
+                 ([ret] ret)
+                 ([ret x]
+                  (let [k (f x)
+                        pre-existing (get ret k)
+                        ll (or pre-existing
+                               (LinkedList.))]
+                    (.add ^LinkedList ll ^Object x)
+                    (if-not pre-existing
+                      (assoc! ret k ll)
+                      ret))))
+               (transient {})
+               coll))))
+
 (defn partition-map
   "Similar to piecewise-map. This partitions the collection by the result of (pred x) for
   each x in coll, then applies the functions in fmap directly to the partitions whole,
@@ -265,13 +298,14 @@
      coll
      (let [len (count coll)
            arr (make-array Object len)
-           rmap (group-by (zip-from (range)) (comp pred val) coll)
+           rmap (group-by-mutable
+                 (zip-from (range)) (comp pred val) coll)
            fdefault (get fmap :default identity)
-           results (->> rmap
-                        (sequence (map (fn [[r kvs]]
-                                         (let [res ((if-let [f (fmap r)] f fdefault)
-                                                    (vals kvs))]
-                                           (sequence (zip-from (keys kvs)) res))))))]
+           results (sequence (map (fn [[r kvs]]
+                                    (let [res ((if-let [f (fmap r)] f fdefault)
+                                               (vals kvs))]
+                                      (sequence (zip-from (keys kvs)) res))))
+                             rmap)]
        (doseq [result results]
          (doseq [item result]
            (aset ^"[Ljava.lang.Object;" arr ^long (key item) ^Object (val item))))
@@ -281,14 +315,14 @@
          ;; Can't assume any coll is finite
          len (count input)
          arr (make-array Object len)
-         rmap (group-by (zip-from (range)) (comp pred first val) input)
+         rmap (group-by-mutable (zip-from (range)) (comp pred first val) input)
          fdefault (get fmap :default (fn [id & _] id))
-         results (->> rmap
-                      (sequence (map (fn [[r kvs]]
-                                       (let [res (apply (if-let [f (fmap r)] f fdefault)
-                                                        (apply map list (vals kvs)))]
-                                         (sequence (zip-from (keys kvs))
-                                                   res))))))]
+         results (sequence (map (fn [[r kvs]]
+                                  (let [res (apply (if-let [f (fmap r)] f fdefault)
+                                                   (apply map list (vals kvs)))]
+                                    (sequence (zip-from (keys kvs))
+                                              res))))
+                           rmap)]
      (doseq [result results
              item result]
        (aset ^"[Ljava.lang.Object;" arr (key item) ^Object (val item)))

--- a/test/utiliva/core_test.clj
+++ b/test/utiliva/core_test.clj
@@ -99,6 +99,7 @@
 (def coll-3 (map #(if (even? %) (inc %) (dec %)) (range 1000)))
 (def coll-4 (map #(if (even? %) (inc %) %) (range 1000)))
 (def coll-5 (map #(if (zero? (mod % 3)) (inc %) (dec %)) (range 1000)))
+(def coll-6 (map #(if (even? %) % nil) (range 100)))
 (deftest unit:piecewise-partition
   (are [x] (= x coll-3)
     (c/piecewise-map even? {true inc false dec} (range 1000))
@@ -130,7 +131,7 @@
     (c/piecewise-pmap #(mod % 3) {:default dec 0 inc} ())
     (c/partition-map #(mod % 3) {:default #(map dec %) 0 #(map inc %)} ())
     (c/partition-pmap #(mod % 3) {:default #(map dec %) 0 #(map inc %)} ()))
-  (are [x] (= coll-0 x)
+  (are [x] (= coll-6 x)
     (c/partition-map even? {false (constantly ())} (range 100))
     (c/partition-map even? {false (constantly nil)} (range 100))
     (c/partition-pmap even? {false (constantly ())} (range 100))


### PR DESCRIPTION
On my own machine, criterium indicated that this change results in 25-30% less overhead in partition-map for a series of dumb examples (with `identity` as the mapping function for all cases).

Partition-map, as written, assumes a finite result-set. The basic idea for this optimization is that, since the size of the resulting sequence is known, there is no need to do any kind of sorting to put things back into order. Simply create an array, and insert items into their corresponding indexes.

I also made a small change in behavior that fixes what I believe to be undesirable behavior. In the previous version of partition-map, you could map one or more partitions to a result set of smaller order, with the result that these values would simply be dropped from the resulting sequence:

```clj
(= (partition-map even? {false (constantly ())} (range 10))
   (filter even? (range 10))
   '(0 2 4 8))
```

On the other hand, if you mapped a partition to a larger sequence of values than was input, superfluous values would simply be dropped (i.e., you could only shrink the results, not grow them).

When I wrote the original implementation, this ~~bug~~ feature was a compromise for the sake of performance; it didn't seem obvious to me how to retain information about those positions without sacrificing speed.

In this new implementation, it's trivial to retain nil values for dropped partitions, and (admittedly very little) extra work is required to drop those values from the result. On the assumption that no consumer of partition-map relied on this "feature," I've modified the tests that checked for this behavior.