### PR TITLE
EVA-966 - Don't require GPG signing when pushing dependency to clojars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 bin/
 pom.xml
 target/
+.classpath
+.settings/

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 > *utiliva, compound Latin substantive adjective* - Things for doing useful stuff 
 
-```
-[com.workiva/utiliva "0.1.0"]
-```
----
-
 **Utiliva** is a collection of generalized doodads we've found useful in Workiva projects. The library is split into several namespaces: `alpha`, `comparator`, `control`, `core`, `macros`, `recursion`, `sorted-cache`, and `uuid`.
 
 ## > utiliva.core

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,10 @@
                  [com.workiva/tesserae "1.0.0"]
                  [backtick "0.3.4"]]
 
+  :deploy-repositories {"clojars"
+                        {:url "https://repo.clojars.org"
+                         :sign-releases false}}
+
   :source-paths      ["src"]
   :test-paths        ["test"]
 


### PR DESCRIPTION
## Description of Changes

 - Previous Artifacts have been deployed to Clojars without GPG signing, this overrides the default `lein deploy clojars` profile to not use GPG signing

## Proposed Testing Steps (If Applicable)

  -

## Relevant Issues (If Applicable)

  -

## Maintainer Notifications

  -
